### PR TITLE
Fixed a bug where Fox would edgeguard the wrong ledge

### DIFF
--- a/Tactics/Edgeguard.cpp
+++ b/Tactics/Edgeguard.cpp
@@ -82,18 +82,9 @@ void Edgeguard::DetermineChain()
         m_state->m_memory->player_two_on_ground &&
         std::abs(m_state->m_memory->player_two_x) < m_state->getStageEdgeGroundPosition())
     {
-        if(m_state->m_memory->player_two_x > 0)
-        {
-            CreateChain2(Walk, true);
-            m_chain->PressButtons();
-            return;
-        }
-        else
-        {
-            CreateChain2(Walk, false);
-            m_chain->PressButtons();
-            return;
-        }
+        CreateChain2(Walk, m_state->m_memory->player_one_x > 0 ? true : false);
+        m_chain->PressButtons();
+        return;
     }
 
     //If we're still on the stage, see if it's safe to grab the edge


### PR DESCRIPTION
For Issue #43 
Fixed a bug where Fox would edgeguard the wrong ledge if he was on the opposite side of the stage when player one grabbed the ledge, also reduced the size of the file by a little by using a ternary operator